### PR TITLE
FIX extract_text_and_figures, ValueError: unsupported colorspace

### DIFF
--- a/app/paper/parser.py
+++ b/app/paper/parser.py
@@ -31,11 +31,9 @@ def extract_text_and_figures(pdf_path):
             pix = fitz.Pixmap(doc, xref)  # Create Pixmap image
 
             # Save image in desired format (here, PNG)
-            if pix.n < 5:  # Grayscale or RGB
-                img_bytes = pix.tobytes("png")
-            else:  # CMYK: Convert to RGB first
+            if not pix.colorspace.name in (fitz.csGRAY.name, fitz.csRGB.name):
                 pix = fitz.Pixmap(fitz.csRGB, pix)
-                img_bytes = pix.tobytes("png")
+            img_bytes = pix.tobytes("png")
 
             figures.append(img_bytes)
 


### PR DESCRIPTION
ValueError occurred while processing PNG in some PDF files.

https://github.com/pymupdf/PyMuPDF/issues/469
https://github.com/ArtifexSoftware/pdf2docx/issues/51